### PR TITLE
iOS8 Location Updates

### DIFF
--- a/lab3/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/lab3/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -7,13 +7,28 @@
     },
     {
       "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "40x40",
       "scale" : "2x"
     },
     {
       "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",

--- a/lab3/ViewController.h
+++ b/lab3/ViewController.h
@@ -7,8 +7,9 @@
 //
 
 #import <UIKit/UIKit.h>
+#import <CoreLocation/CoreLocation.h>
 
-@interface ViewController : UIViewController <UIScrollViewDelegate>
+@interface ViewController : UIViewController <UIScrollViewDelegate, CLLocationManagerDelegate>
 //@property (weak, nonatomic) IBOutlet UIImageView *imageView;
 //@property (weak, nonatomic) IBOutlet UIScrollView *scrollView;
 
@@ -22,6 +23,10 @@
 - (IBAction)MLKButton:(id)sender;
 
 - (IBAction)ENGRTab:(id)sender;
+
+- (void) locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error;
+- (void) locationManager:(CLLocationManager *)manager didUpdateToLocation:(CLLocation *)newLocation fromLocation:(CLLocation *)oldLocation;
+- (void) locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations;
 
 //new values -- TODO these are just for testing -- to be removed at the end
 @property (weak, nonatomic) IBOutlet UILabel *testLabelLatitude;

--- a/lab3/ViewController.h
+++ b/lab3/ViewController.h
@@ -25,7 +25,6 @@
 - (IBAction)ENGRTab:(id)sender;
 
 - (void) locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error;
-- (void) locationManager:(CLLocationManager *)manager didUpdateToLocation:(CLLocation *)newLocation fromLocation:(CLLocation *)oldLocation;
 - (void) locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations;
 
 //new values -- TODO these are just for testing -- to be removed at the end

--- a/lab3/ViewController.m
+++ b/lab3/ViewController.m
@@ -80,6 +80,11 @@ CLPlacemark *placemark;
     //location initialization
     locationManager = [[CLLocationManager alloc] init]; //for latitude/lognitude
     geocoder = [[CLGeocoder alloc] init]; //for actual address
+    
+    if (CLLocationManager.authorizationStatus == kCLAuthorizationStatusNotDetermined) {
+        [locationManager requestWhenInUseAuthorization];
+    }
+    
     locationManager.delegate = self;
     locationManager.desiredAccuracy = kCLLocationAccuracyBest;
     
@@ -96,6 +101,31 @@ CLPlacemark *placemark;
     UIAlertView *errorAlert = [[UIAlertView alloc]
                                initWithTitle:@"Error" message:@"Failed to Get Your Location" delegate:nil cancelButtonTitle:@"OK" otherButtonTitles:nil];
     [errorAlert show];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations
+{
+    CLLocation *currentLocation = locations.lastObject;
+    
+    if (currentLocation != nil) {
+        _testLabelLongitude.text = [NSString stringWithFormat:@"%.8f", currentLocation.coordinate.longitude];
+        _testLabelLatitude.text = [NSString stringWithFormat:@"%.8f", currentLocation.coordinate.latitude];
+    }
+    
+    //get the actual address
+    [geocoder reverseGeocodeLocation:currentLocation completionHandler:^(NSArray *placemarks, NSError *error) {
+        if(error == nil && [placemarks count] > 0) {
+            placemark = [placemarks lastObject];
+            self.testLabelAddress.text = [NSString stringWithFormat:@"%@ %@\n%@ %@\n%@\n%@",
+                                          placemark.subThoroughfare, placemark.thoroughfare,
+                                          placemark.postalCode, placemark.locality,
+                                          placemark.administrativeArea,
+                                          placemark.country];
+        }
+        else {
+            NSLog(@"%@", error.debugDescription);
+        }
+    }];
 }
 
 - (void)locationManager:(CLLocationManager *)manager didUpdateToLocation:(CLLocation *)newLocation fromLocation:(CLLocation *)oldLocation

--- a/lab3/ViewController.m
+++ b/lab3/ViewController.m
@@ -128,36 +128,6 @@ CLPlacemark *placemark;
     }];
 }
 
-- (void)locationManager:(CLLocationManager *)manager didUpdateToLocation:(CLLocation *)newLocation fromLocation:(CLLocation *)oldLocation
-{
-    NSLog(@"didUpdateToLocation: %@", newLocation);
-    CLLocation *currentLocation = newLocation;
-    
-    if (currentLocation != nil) {
-        _testLabelLongitude.text = [NSString stringWithFormat:@"%.8f", currentLocation.coordinate.longitude];
-        _testLabelLatitude.text = [NSString stringWithFormat:@"%.8f", currentLocation.coordinate.latitude];
-    }
-    
-    //get the actual address
-    [geocoder reverseGeocodeLocation:currentLocation completionHandler:^(NSArray *placemarks, NSError *error) {
-        if(error == nil && [placemarks count] > 0) {
-            placemark = [placemarks lastObject];
-            self.testLabelAddress.text = [NSString stringWithFormat:@"%@ %@\n%@ %@\n%@\n%@",
-                                 placemark.subThoroughfare, placemark.thoroughfare,
-                                 placemark.postalCode, placemark.locality,
-                                 placemark.administrativeArea,
-                                 placemark.country];
-        }
-        else {
-            NSLog(@"%@", error.debugDescription);
-        }
-    }];
-    
-    
-    
-    
-}
-
 ///////////
 
 - (void)didReceiveMemoryWarning

--- a/lab3/lab3-Info.plist
+++ b/lab3/lab3-Info.plist
@@ -38,6 +38,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Locate user on campus</string>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
Updates weren't working because it's needed to request authorization before. 

The authorization request silently fails if the "NSLocationWhenInUseUsageDescription" key isn't defined in the info.plist
